### PR TITLE
refactor: move tills

### DIFF
--- a/src/til/20240315-fast-forward-merges-on-github.md
+++ b/src/til/20240315-fast-forward-merges-on-github.md
@@ -1,7 +1,7 @@
 ---
 title: Fast-forward merges on GitHub
-date: 20240315
-...
+date: 2024-03-15
+---
 
 # Fast-forward merges on GitHub
 

--- a/src/til/20240321-jq.md
+++ b/src/til/20240321-jq.md
@@ -1,7 +1,7 @@
 ---
 title: A bit of jq
-date: 20240321
-...
+date: 2024-03-21
+---
 
 # A bit of jq
 

--- a/src/til/20240323-map-capslock-to-escape.md
+++ b/src/til/20240323-map-capslock-to-escape.md
@@ -1,7 +1,7 @@
 ---
 title: Map capslock to escape on Fedora with Gnome
-date: 20240323
-...
+date: 2024-03-23
+---
 
 # Map capslock to escape on Fedora with Gnome
 

--- a/src/til/20240413-rebase-from-the-start.md
+++ b/src/til/20240413-rebase-from-the-start.md
@@ -1,7 +1,7 @@
 ---
 title: Interactive rebase from the start
-date: 20240413
-...
+date: 2024-04-13
+---
 
 # Interactive rebase on the beginning of a repo
 

--- a/src/til/20240424-corepack-prepare.md
+++ b/src/til/20240424-corepack-prepare.md
@@ -1,7 +1,7 @@
 ---
 title: Corepack prepare
-date: 20240424
-...
+date: 2024-04-24
+---
 
 # Corepack prepare
 

--- a/src/til/20240426-vim-for-long-commands.md
+++ b/src/til/20240426-vim-for-long-commands.md
@@ -1,7 +1,7 @@
 ---
 title: Using Vim for long commands in bash
-date: 20240426
-...
+date: 2024-04-26
+---
 
 # Using vim for long command-line commands in bash
 

--- a/src/til/20240523-git-show-file-in-other-branch.md
+++ b/src/til/20240523-git-show-file-in-other-branch.md
@@ -1,7 +1,7 @@
 ---
 title: How to show the contents of a file in a different branch
-date: 20240523
-...
+date: 2024-05-23
+---
 
 # How to show the contents of a file in a different branch
 

--- a/src/til/20240616-escaping-a-backtick-in-markdown.md
+++ b/src/til/20240616-escaping-a-backtick-in-markdown.md
@@ -1,7 +1,7 @@
 ---
 title: Escaping a backtick in Markdown
-date: 20240616
-...
+date: 2024-06-16
+---
 
 # Escaping a backtick in Markdown
 

--- a/src/til/20240616-special-characters-in-vim.md
+++ b/src/til/20240616-special-characters-in-vim.md
@@ -1,7 +1,7 @@
 ---
 title: Special characters in Vim
-date: 20240616
-...
+date: 2024-06-16
+---
 
 # Special characters in Vim
 

--- a/src/til/20240701-reading-logs-on-fedora.md
+++ b/src/til/20240701-reading-logs-on-fedora.md
@@ -1,7 +1,7 @@
 ---
 title: Reading logs on Fedora
-date: 20240701
-...
+date: 2024-07-01
+---
 
 # Reading logs on Fedora
 

--- a/src/til/20240703-disown.md
+++ b/src/til/20240703-disown.md
@@ -1,7 +1,7 @@
 ---
 title: disown
-date: 20240703
-...
+date: 2024-07-03
+---
 
 # disown
 

--- a/src/til/20240828-eslint-config-js-vs-mjs.md
+++ b/src/til/20240828-eslint-config-js-vs-mjs.md
@@ -1,7 +1,7 @@
 ---
 title: ESLint config file extension
-date: 20240828
-...
+date: 2024-08-28
+---
 
 # ESLint config file extension
 

--- a/src/til/20240905-mistyping-a-password-using-sudo.md
+++ b/src/til/20240905-mistyping-a-password-using-sudo.md
@@ -1,7 +1,7 @@
 ---
 title: Mistyping a password using sudo
-date: 20240905
-...
+date: 2024-09-05
+---
 
 When you accidentally press a cursor key while entering a password for `sudo`,
 you may end up entering a different password than intended.

--- a/src/til/20240920-prettierignore-is-pretty-smart.md
+++ b/src/til/20240920-prettierignore-is-pretty-smart.md
@@ -1,7 +1,7 @@
 ---
 title: .prettierignore is pretty smart
-date: 20240920
-...
+date: 2024-09-20
+---
 
 # `.prettierignore` is pretty smart
 

--- a/src/til/20241007-git-restore-in-one-command.md
+++ b/src/til/20241007-git-restore-in-one-command.md
@@ -1,7 +1,7 @@
 ---
 title: git restore in one just command
-date: 20241007
-...
+date: 2024-10-07
+---
 
 # git restore in just one command
 

--- a/src/til/20241017-git-pathspecs.md
+++ b/src/til/20241017-git-pathspecs.md
@@ -1,7 +1,7 @@
 ---
 title: git pathspecs
-date: 20241017
-...
+date: 2024-10-17
+---
 
 # git pathspecs
 

--- a/src/til/20241023-remove-node_modules-quickly.md
+++ b/src/til/20241023-remove-node_modules-quickly.md
@@ -1,7 +1,7 @@
 ---
 title: Remove node_modules quickly
-date: 20241023
-...
+date: 2024-10-23
+---
 
 # Remove node_modules quickly
 

--- a/src/til/20241107-git-known-files.md
+++ b/src/til/20241107-git-known-files.md
@@ -1,7 +1,7 @@
 ---
 title: Git known files
-date: 20241107
-...
+date: 2024-11-07
+---
 
 # Git known files
 

--- a/src/til/20241208-BIOS-OEM-Windows-key.md
+++ b/src/til/20241208-BIOS-OEM-Windows-key.md
@@ -1,7 +1,7 @@
 ---
 title: BIOS OEM Windows key
-date: 20241208
-...
+date: 2024-12-08
+---
 
 # BIOS OEM Windows Key
 

--- a/src/til/20250104-removing-unused-bootmanager-options.md
+++ b/src/til/20250104-removing-unused-bootmanager-options.md
@@ -1,7 +1,7 @@
 ---
 title: Removing unused bootmanager options
-date: 20250104
-...
+date: 2025-01-04
+---
 
 # Removing unused bootmanager options
 

--- a/src/til/20250207-opening-an-empty-vertical-split-in-vim.md
+++ b/src/til/20250207-opening-an-empty-vertical-split-in-vim.md
@@ -1,7 +1,7 @@
 ---
 title: Opening an empty vertical split in vim
-date: 20250207
-...
+date: 2025-02-07
+---
 
 # Opening an empty vertical split in vim
 

--- a/src/til/20250210-unicode-characters-in-vim.md
+++ b/src/til/20250210-unicode-characters-in-vim.md
@@ -1,7 +1,7 @@
 ---
 title: Unicode characters in vim
-date: 20250210
-...
+date: 2025-02-10
+---
 
 # Unicode characters in vim
 

--- a/src/til/20250614-git-check-ignore.md
+++ b/src/til/20250614-git-check-ignore.md
@@ -1,7 +1,7 @@
 ---
 title: git check-ignore
-date: 20250614
-...
+date: 2025-06-14
+---
 
 # git check-ignore
 


### PR DESCRIPTION
In preparation for using Astro:

- Move Markdown files from *tils/* to *src/til/*
- Use proper frontmatter code fences, using `---` for an opening fence and `...` for a closing one is a YAML thing, not a frontmatter thing.
- Convert the date from `yyyymmdd` to `yyyy-mm-dd`