### PR TITLE
chore: pnpm/dependabot cooldowns

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,8 @@ updates:
       day: "saturday"
       time: "00:00"
       timezone: "Etc/UTC"
+    cooldown:
+      default-days: 5
     groups:
       # group all patch and minor version updates in one pull request
       minor-dependencies:
@@ -26,3 +28,5 @@ updates:
       day: "saturday"
       time: "00:00"
       timezone: "Etc/UTC"
+    cooldown:
+      default-days: 5

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,2 @@
 pnpm-lock.yaml
+pnpm-workspace.yaml

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,5 @@
+minimumReleaseAge: 7200
+
 saveExact: true
 
-savePrefix: ""
+savePrefix: ''


### PR DESCRIPTION
Add 5 day cooldowns for installing packages. pnpm uses minimumReleaseAge (in seconds) and Dependabot uses cooldown.default-days

Add pnpm-workspace.yaml to .prettierignore because `pnpm config` only knows its own formatting.